### PR TITLE
Escape cells in CSV that contain newlines.

### DIFF
--- a/src/logger.py
+++ b/src/logger.py
@@ -13,7 +13,7 @@ from sets import Set
 
 def csv_escape(value):
     """return escaped and quoted as needed to be in a comma-separated CSV"""
-    if ',' in value:
+    if ',' in value or '\n' in value:
         # quote value
         return '"%s"'%value.replace('"', '""')
     return value


### PR DESCRIPTION
This adds quotes in the CSV file around cells that contain newlines. When loaded in Excel or libreoffice this cell will import with multiple lines, and won't break apart the CSV row.